### PR TITLE
Sequential rewards schemes

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -87,7 +87,7 @@ module.exports = {
     settings: {
       optimizer: {
         enabled: true,
-        runs: 20000,
+        runs: 15000,
       }
     }
   },


### PR DESCRIPTION
In this PR, several sequential reward schemes can be set, and user rewards are tracked separately for each one. The cost of use is increased by a single SLOAD on transfer, although the code is slightly more complex.

Each reward scheme can have its own token, and unaccumulated rewards are never lost.