### PR TITLE
Fix: init pool on invest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,5 +20,4 @@ jobs:
           version: nightly
 
       - name: Run tests
-        run: forge test --match-path test/StrategyMigrator.t.sol -vvv
-        run: forge test --match-path test/StrategyTest.t.sol -vvv
+        run: MAINNET_RPC=${{ secrets.MAINNET_RPC }} ARBITRUM_RPC=${{ secrets.ARBITRUM_RPC }} forge test -vvv

--- a/contracts/Strategy.sol
+++ b/contracts/Strategy.sol
@@ -154,12 +154,10 @@ contract Strategy is AccessControl, ERC20Rewards, StrategyMigrator { // TODO: I'
         uint256 cached_ = cached; // We could read the real balance, but this is a bit safer
 
         require(base == pool_.base(), "Mismatched base");
-        require(pool_.getFYTokenBalance() - pool_.totalSupply() == 0, "Only with no fyToken in the pool"); // This could be removed if using `pool.init`
 
         // Mint LP tokens and initialize the pool
         base.safeTransfer(address(pool_), cached_);
-        (,, poolTokensObtained) = pool_.mint(address(this), address(this), 0, type(uint256).max); // This could be replaced for `pool.init` and simplify things, but it is hard to find the right block to test it.
-        // (,, poolTokensObtained) = pool_.init(address(this));
+        (,, poolTokensObtained) = pool_.init(address(this));
         cached = poolTokensObtained;
 
         // Update state variables

--- a/foundry.toml
+++ b/foundry.toml
@@ -4,6 +4,6 @@ out = 'artifacts'
 libs = ['lib']
 solc_version = '0.8.15'
 
-rpc_endpoints = { MAINNET = "${MAINNET_RPC}", ARBITRUM = "${ARBITRUM_RPC}", UNIT_TESTS = "https://rpc.tenderly.co/fork/80702a3d-f55f-4168-9d6d-954878f7240a", TENDERLY = "https://rpc.tenderly.co/fork/6c5d4b71-8bf2-4a56-90eb-7fd26e2dfe35" }
+rpc_endpoints = { MAINNET = "${MAINNET_RPC}", ARBITRUM = "${ARBITRUM_RPC}", UNIT_TESTS = "https://rpc.tenderly.co/fork/eb4cc00e-c12c-45f5-905a-04f0cfdefa2f", TENDERLY = "https://rpc.tenderly.co/fork/6c5d4b71-8bf2-4a56-90eb-7fd26e2dfe35" }
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/foundry.toml
+++ b/foundry.toml
@@ -4,6 +4,6 @@ out = 'artifacts'
 libs = ['lib']
 solc_version = '0.8.15'
 
-rpc_endpoints = { MAINNET = "${MAINNET_RPC}", ARBITRUM = "${ARBITRUM_RPC}", TENDERLY = "https://rpc.tenderly.co/fork/6c5d4b71-8bf2-4a56-90eb-7fd26e2dfe35" }
+rpc_endpoints = { MAINNET = "${MAINNET_RPC}", ARBITRUM = "${ARBITRUM_RPC}", UNIT_TESTS = "https://rpc.tenderly.co/fork/80702a3d-f55f-4168-9d6d-954878f7240a", TENDERLY = "https://rpc.tenderly.co/fork/6c5d4b71-8bf2-4a56-90eb-7fd26e2dfe35" }
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/test/StrategyTest.t.sol
+++ b/test/StrategyTest.t.sol
@@ -11,10 +11,11 @@ import {IPool} from "@yield-protocol/yieldspace-tv/src/interfaces/IPool.sol";
 import {IERC20} from "@yield-protocol/utils-v2/contracts/token/IERC20.sol";
 import {IERC20Metadata} from "@yield-protocol/utils-v2/contracts/token/IERC20Metadata.sol";
 import { TestConstants } from "./utils/TestConstants.sol";
+import { TestExtensions } from "./utils/TestExtensions.sol";
 import "@yield-protocol/vault-v2/contracts/interfaces/DataTypes.sol";
 
 
-abstract contract DeployedState is Test, TestConstants {
+abstract contract DeployedState is Test, TestConstants, TestExtensions {
     using stdStorage for StdStorage;
 
     // We use a custom tenderly fork with pools that are not initialized, but fyToken that have been added to the cauldron
@@ -39,48 +40,6 @@ abstract contract DeployedState is Test, TestConstants {
     IERC20Metadata baseToken;
     IERC20Metadata sharesToken;
     Strategy strategy;
-
-    mapping(string => uint256) tracked;
-
-    function cash(IERC20 token, address user, uint256 amount) public {
-        uint256 start = token.balanceOf(user);
-        deal(address(token), user, start + amount);
-    }
-
-    function track(string memory id, uint256 amount) public {
-        tracked[id] = amount;
-    }
-
-    function assertTrackPlusEq(string memory id, uint256 plus, uint256 amount) public {
-        assertEq(tracked[id] + plus, amount);
-    }
-
-    function assertTrackMinusEq(string memory id, uint256 minus, uint256 amount) public {
-        assertEq(tracked[id] - minus, amount);
-    }
-
-    function assertTrackPlusApproxEqAbs(string memory id, uint256 plus, uint256 amount, uint256 delta) public {
-        assertApproxEqAbs(tracked[id] + plus, amount, delta);
-    }
-
-    function assertTrackMinusApproxEqAbs(string memory id, uint256 minus, uint256 amount, uint256 delta) public {
-        assertApproxEqAbs(tracked[id] - minus, amount, delta);
-    }
-
-    function assertApproxGeAbs(uint256 a, uint256 b, uint256 delta) public {
-        assertGe(a, b);
-        assertApproxEqAbs(a, b, delta);
-    }
-
-    function assertTrackPlusApproxGeAbs(string memory id, uint256 plus, uint256 amount, uint256 delta) public {
-        assertGe(tracked[id] + plus, amount);
-        assertApproxEqAbs(tracked[id] + plus, amount, delta);
-    }
-
-    function assertTrackMinusApproxGeAbs(string memory id, uint256 minus, uint256 amount, uint256 delta) public {
-        assertGe(tracked[id] - minus, amount);
-        assertApproxEqAbs(tracked[id] - minus, amount, delta);
-    }
 
     function setUp() public virtual {
         vm.createSelectFork(UNIT_TESTS);

--- a/test/StrategyTest.t.sol
+++ b/test/StrategyTest.t.sol
@@ -13,20 +13,16 @@ import {IERC20Metadata} from "@yield-protocol/utils-v2/contracts/token/IERC20Met
 import { TestConstants } from "./utils/TestConstants.sol";
 import "@yield-protocol/vault-v2/contracts/interfaces/DataTypes.sol";
 
-interface DonorStrategy {
-    function seriesId() external view returns (bytes6);
-    function pool() external view returns (IPool);
-}
 
 abstract contract DeployedState is Test, TestConstants {
     using stdStorage for StdStorage;
 
     // We use a custom tenderly fork with pools that are not initialized, but fyToken that have been added to the cauldron
     // Pools:
-    // 0x303030390000, 0x8c91088DEcc62E3e377C7e0085179518D2D491F6
-    // 0x303130390000, 0xD57355f1CA20408d50b136b1279bA7833dd77E82
-    // 0x303230390000, 0xb052ea3b1cFa1E91180019f6247c67b92B9D4F6A
-    // 0x313830390000, 0x9b4397977a5567E49eF300311ad82f1D9749B22f
+    //  0x303030390000 0xe2Cf890a20c022a034b2d89e6C573B68eD6feb70
+    //  0x303130390000 0x304765A87fD5f28A87f2078A88a42a575b973FF0
+    //  0x303230390000 0x8B4be6CD156CbD51Df8Fe603aD46DD3cd06A98d4
+    //  0x313830390000 0x16123dDcb3fBcA9b962D51d4B7001148e8Ac3036
 
     address deployer = address(bytes20(keccak256("deployer")));
     address alice = address(bytes20(keccak256("alice")));
@@ -36,7 +32,6 @@ abstract contract DeployedState is Test, TestConstants {
     address timelock = 0x3b870db67a45611CF4723d44487EAF398fAc51E3;
     ICauldron cauldron = ICauldron(0xc88191F8cb8e6D4a668B047c1C8503432c3Ca867);
     ILadle ladle = ILadle(0x6cB18fF2A33e981D1e38A663Ca056c0a5265066A);
-    DonorStrategy donorStrategy = DonorStrategy(0x7ACFe277dEd15CabA6a8Da2972b1eb93fe1e2cCD); // We use this strategy as the source for the pool and fyToken addresses.
 
     bytes6 seriesId;
     IPool pool;
@@ -90,8 +85,8 @@ abstract contract DeployedState is Test, TestConstants {
     function setUp() public virtual {
         vm.createSelectFork(UNIT_TESTS);
 
-        seriesId = 0x303130390000;
-        pool = IPool(0xD57355f1CA20408d50b136b1279bA7833dd77E82);
+        seriesId = 0x313830390000;
+        pool = IPool(0x16123dDcb3fBcA9b962D51d4B7001148e8Ac3036);
         fyToken = IFYToken(address(pool.fyToken()));
         baseToken = pool.baseToken();
         sharesToken = pool.sharesToken();

--- a/test/harness/StrategyHarness.t.sol
+++ b/test/harness/StrategyHarness.t.sol
@@ -11,19 +11,20 @@ import {IPool} from "@yield-protocol/yieldspace-tv/src/interfaces/IPool.sol";
 import {IERC20} from "@yield-protocol/utils-v2/contracts/token/IERC20.sol";
 import {IERC20Metadata} from "@yield-protocol/utils-v2/contracts/token/IERC20Metadata.sol";
 import { TestConstants } from "./../utils/TestConstants.sol";
+import { TestExtensions } from "./../utils/TestExtensions.sol";
 import "@yield-protocol/vault-v2/contracts/interfaces/DataTypes.sol";
 
 /// @dev This test harness tests that a deployed and invested strategy is functional.
 
-abstract contract ZeroState is Test, TestConstants {
+abstract contract ZeroState is Test, TestConstants, TestExtensions {
     using stdStorage for StdStorage;
+
+    bool ci; // Skip the tests on CI
 
     address deployer = address(bytes20(keccak256("deployer")));
     address alice = address(bytes20(keccak256("alice")));
     address bob = address(bytes20(keccak256("bob")));
     address hole = address(bytes20(keccak256("hole")));
-
-    string network = TENDERLY;
 
     address timelock;
     ICauldron cauldron;
@@ -35,47 +36,6 @@ abstract contract ZeroState is Test, TestConstants {
     IERC20Metadata baseToken;
     IERC20Metadata sharesToken;
 
-    mapping(string => uint256) tracked;
-
-    function cash(IERC20 token, address user, uint256 amount) public {
-        uint256 start = token.balanceOf(user);
-        deal(address(token), user, start + amount);
-    }
-
-    function track(string memory id, uint256 amount) public {
-        tracked[id] = amount;
-    }
-
-    function assertTrackPlusEq(string memory id, uint256 plus, uint256 amount) public {
-        assertEq(tracked[id] + plus, amount);
-    }
-
-    function assertTrackMinusEq(string memory id, uint256 minus, uint256 amount) public {
-        assertEq(tracked[id] - minus, amount);
-    }
-
-    function assertTrackPlusApproxEqAbs(string memory id, uint256 plus, uint256 amount, uint256 delta) public {
-        assertApproxEqAbs(tracked[id] + plus, amount, delta);
-    }
-
-    function assertTrackMinusApproxEqAbs(string memory id, uint256 minus, uint256 amount, uint256 delta) public {
-        assertApproxEqAbs(tracked[id] - minus, amount, delta);
-    }
-
-    function assertApproxGeAbs(uint256 a, uint256 b, uint256 delta) public {
-        assertGe(a, b);
-        assertApproxEqAbs(a, b, delta);
-    }
-
-    function assertTrackPlusApproxGeAbs(string memory id, uint256 plus, uint256 amount, uint256 delta) public {
-        assertGe(tracked[id] + plus, amount);
-        assertApproxEqAbs(tracked[id] + plus, amount, delta);
-    }
-
-    function assertTrackMinusApproxGeAbs(string memory id, uint256 minus, uint256 amount, uint256 delta) public {
-        assertGe(tracked[id] - minus, amount);
-        assertApproxEqAbs(tracked[id] - minus, amount, delta);
-    }
 
     modifier onlyEjected() {
         if (strategy.state() != Strategy.State.EJECTED) {
@@ -85,7 +45,6 @@ abstract contract ZeroState is Test, TestConstants {
         _;
     }
 
-
     modifier onlyDrained() {
         if (strategy.state() != Strategy.State.DRAINED) {
             console2.log("Strategy not drained, skipping...");
@@ -94,44 +53,46 @@ abstract contract ZeroState is Test, TestConstants {
         _;
     }
 
-    function equal(string memory a, string memory b) public returns(bool) {
-        return keccak256(abi.encodePacked(a)) == keccak256(abi.encodePacked(b));
+    modifier skipOnCI() {
+        if (ci == true) {
+            console2.log("On CI, skipping...");
+            return;
+        }
+        _;
     }
 
     function setUp() public virtual {
-        vm.createSelectFork(network);
+        if (!(ci = vm.envOr(CI, true))) {
+            string memory rpc = vm.envOr(RPC, TENDERLY);
+            vm.createSelectFork(rpc);
 
-        if (equal(vm.envString("NETWORK"), "MAINNET")) {
-            timelock = 0x3b870db67a45611CF4723d44487EAF398fAc51E3;
-            cauldron = ICauldron(0xc88191F8cb8e6D4a668B047c1C8503432c3Ca867);
-            ladle = ILadle(0x6cB18fF2A33e981D1e38A663Ca056c0a5265066A);
-        } else if (equal(vm.envString("NETWORK"), "ARBITRUM")) {
-            timelock = 0xd0a22827Aed2eF5198EbEc0093EA33A4CD641b6c;
-            cauldron = ICauldron(0x23cc87FBEBDD67ccE167Fa9Ec6Ad3b7fE3892E30);
-            ladle = ILadle(0x16E25cf364CeCC305590128335B8f327975d0560);
-        }
+            string memory network = vm.envOr(NETWORK, MAINNET);
+            timelock = addresses[network][TIMELOCK];
+            cauldron = ICauldron(addresses[network][LADLE]);
+            ladle = ILadle(addresses[network][CAULDRON]);
 
-        strategy = Strategy(vm.envAddress("STRATEGY"));
-        baseToken = IERC20Metadata(address(strategy.base()));
+            strategy = Strategy(vm.envAddress(STRATEGY));
+            baseToken = IERC20Metadata(address(strategy.base()));
 
-        // Alice has privileged roles
-        vm.startPrank(timelock);
-        strategy.grantRole(Strategy.init.selector, alice);
-        strategy.grantRole(Strategy.invest.selector, alice);
-        strategy.grantRole(Strategy.eject.selector, alice);
-        strategy.grantRole(Strategy.restart.selector, alice);
-        vm.stopPrank();
+            // Alice has privileged roles
+            vm.startPrank(timelock);
+            strategy.grantRole(Strategy.init.selector, alice);
+            strategy.grantRole(Strategy.invest.selector, alice);
+            strategy.grantRole(Strategy.eject.selector, alice);
+            strategy.grantRole(Strategy.restart.selector, alice);
+            vm.stopPrank();
 
-        vm.label(deployer, "deployer");
-        vm.label(alice, "alice");
-        vm.label(bob, "bob");
-        vm.label(hole, "hole");
-        vm.label(address(strategy), "strategy");
+            vm.label(deployer, "deployer");
+            vm.label(alice, "alice");
+            vm.label(bob, "bob");
+            vm.label(hole, "hole");
+            vm.label(address(strategy), "strategy");
+        }     
     }
 }
 
 contract ZeroStateTest is ZeroState {
-    function testHarnessIsInvested() public {
+    function testHarnessIsInvested() public skipOnCI skipOnCI {
         assertTrue(strategy.state() == Strategy.State.INVESTED);
     } 
 }
@@ -141,21 +102,23 @@ abstract contract InvestedState is ZeroState {
     function setUp() public virtual override {
         super.setUp();
 
-        fyToken = strategy.fyToken();
-        pool = strategy.pool();
-        sharesToken = pool.sharesToken();
+        if (!ci) {
+            fyToken = strategy.fyToken();
+            pool = strategy.pool();
+            sharesToken = pool.sharesToken();
 
-        vm.label(address(pool), "pool");
-        vm.label(address(sharesToken), "sharesToken");
-        vm.label(address(baseToken), "baseToken");
-        vm.label(address(fyToken), "fyToken");
+            vm.label(address(pool), "pool");
+            vm.label(address(sharesToken), "sharesToken");
+            vm.label(address(baseToken), "baseToken");
+            vm.label(address(fyToken), "fyToken");
+        }
     } 
 }
 
 
 contract InvestedStateTest is InvestedState {
 
-    function testHarnessMintInvested() public {
+    function testHarnessMintInvested() public skipOnCI {
         console2.log("strategy.mint()");
 
         uint256 poolIn = pool.totalSupply() / 1000;
@@ -175,7 +138,7 @@ contract InvestedStateTest is InvestedState {
         assertTrackPlusEq("strategyPoolBalance", poolIn, pool.balanceOf(address(strategy)));
     }
 
-    function testHarnessBurnInvested() public {
+    function testHarnessBurnInvested() public skipOnCI {
         console2.log("strategy.burn()");
 
         uint256 poolIn = pool.totalSupply() / 1000;
@@ -197,7 +160,7 @@ contract InvestedStateTest is InvestedState {
         assertTrackMinusEq("cached", poolObtained, strategy.cached());
     }
 
-    function testHarnessEjectAuthInvested() public {
+    function testHarnessEjectAuthInvested() public skipOnCI {
         console2.log("strategy.eject()");
 
         vm.expectRevert(bytes("Access denied"));
@@ -205,7 +168,7 @@ contract InvestedStateTest is InvestedState {
         strategy.eject();
     }
 
-    function testHarnessEjectInvested() public {
+    function testHarnessEjectInvested() public skipOnCI {
         console2.log("strategy.eject()");
 
         uint256 expectedBase = pool.balanceOf(address(strategy)) * pool.getBaseBalance() / pool.totalSupply();
@@ -216,7 +179,7 @@ contract InvestedStateTest is InvestedState {
         assertTrue(strategy.state() == Strategy.State.DIVESTED ||strategy.state() == Strategy.State.EJECTED || strategy.state() == Strategy.State.DRAINED);
     } // --> Divested, Ejected or Drained
 
-    function testHarnessNoDivestBeforeMaturityInvested() public {
+    function testHarnessNoDivestBeforeMaturityInvested() public skipOnCI {
         console2.log("strategy.divest()");
 
         vm.expectRevert(bytes("Only after maturity"));
@@ -229,13 +192,15 @@ abstract contract EjectedOrDrainedState is InvestedState {
     function setUp() public virtual override {
         super.setUp();
 
-        vm.prank(alice);
-        strategy.eject();
+        if (!ci) {
+            vm.prank(alice);
+            strategy.eject();
+        }
     }
 }
 
 contract TestEjectedOrDrained is EjectedOrDrainedState {
-    function testHarnessBuyFYTokenEjected() public onlyEjected {
+    function testHarnessBuyFYTokenEjected() public skipOnCI onlyEjected {
         console2.log("strategy.buyFYToken()");
 
         uint256 fyTokenAvailable = fyToken.balanceOf(address(strategy));
@@ -280,7 +245,7 @@ contract TestEjectedOrDrained is EjectedOrDrainedState {
         assertEq(uint256(strategy.state()), 1);
     } // --> Divested
 
-    function testHarnessRestartDrained() public onlyDrained {
+    function testHarnessRestartDrained() public skipOnCI onlyDrained {
         console2.log("strategy.restart()");
         uint256 restartAmount = 10 ** baseToken.decimals();
 
@@ -300,12 +265,12 @@ abstract contract InvestedAfterMaturity is InvestedState {
     function setUp() public virtual override {
         super.setUp();
 
-        vm.warp(pool.maturity());
+       if (!ci) vm.warp(pool.maturity());
     }
 }
 
 contract InvestedAfterMaturityTest is InvestedAfterMaturity {
-    function testHarnessDivestAfterMaturity() public {
+    function testHarnessDivestAfterMaturity() public skipOnCI {
         console2.log("strategy.divest()");
 
         uint256 expectedBase = pool.balanceOf(address(strategy)) * pool.getBaseBalance() / pool.totalSupply();
@@ -325,11 +290,11 @@ abstract contract DivestedState is InvestedAfterMaturity {
     function setUp() public virtual override {
         super.setUp();
 
-        strategy.divest();
+        if (!ci) strategy.divest();
     }
 }
 contract DivestedStateTest is DivestedState {
-    function testHarnessNoRepeatedInit() public {
+    function testHarnessNoRepeatedInit() public skipOnCI {
         console2.log("strategy.init()");
         uint256 initAmount = 1e18;
 
@@ -338,7 +303,7 @@ contract DivestedStateTest is DivestedState {
         strategy.init(hole);
     }
 
-    function testHarnessMintDivested() public {
+    function testHarnessMintDivested() public skipOnCI {
         console2.log("strategy.mint()");
         uint256 baseIn = strategy.cached() / 1000;
         uint256 expectedMinted = (baseIn * strategy.totalSupply()) / strategy.cached();
@@ -354,7 +319,7 @@ contract DivestedStateTest is DivestedState {
         assertTrackPlusEq("cached", baseIn, strategy.cached());
     }
 
-    function testHarnessBurnDivested() public {
+    function testHarnessBurnDivested() public skipOnCI {
         console2.log("strategy.burn()");
         // Let's get some tokens
         uint256 baseIn = strategy.cached() / 1000;

--- a/test/harness/testHarness.sh
+++ b/test/harness/testHarness.sh
@@ -6,6 +6,7 @@ STRATEGIES=(\
   0x7CEde4B5aC739677A0F677F1B0C9884355F2EdCb\ 
 )
 
+export CI=false
 export RPC="TENDERLY"
 export NETWORK="ARBITRUM"
 export MOCK=false

--- a/test/utils/TestConstants.sol
+++ b/test/utils/TestConstants.sol
@@ -32,6 +32,7 @@ contract TestConstants {
     string public constant MAINNET = "MAINNET";
     string public constant ARBITRUM = "ARBITRUM";
     string public constant TENDERLY = "TENDERLY";
+    string public constant UNIT_TESTS = "UNIT_TESTS";
     string public constant MOCK = "MOCK";
     string public constant NETWORK = "NETWORK";
 

--- a/test/utils/TestConstants.sol
+++ b/test/utils/TestConstants.sol
@@ -28,6 +28,8 @@ contract TestConstants {
 
     uint32 public constant EOJUN22 = 1656039600;
 
+    string public constant CI = "CI";
+    string public constant RPC = "RPC";
     string public constant LOCALHOST = "LOCALHOST";
     string public constant MAINNET = "MAINNET";
     string public constant ARBITRUM = "ARBITRUM";
@@ -39,6 +41,7 @@ contract TestConstants {
     string public constant TIMELOCK = "TIMELOCK";
     string public constant CAULDRON = "CAULDRON";
     string public constant LADLE = "LADLE";
+    string public constant STRATEGY = "STRATEGY";
 
     mapping (string => mapping (string => address)) public addresses;
 


### PR DESCRIPTION
Unit tests running on tenderly fork at https://dashboard.tenderly.co/Yield/v2/fork/eb4cc00e-c12c-45f5-905a-04f0cfdefa2f, created as the Sep-Mar mainnet roll but without initializing pools or rolling strategies.