### PR TITLE
Extract fytoken

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -4,6 +4,6 @@ out = 'artifacts'
 libs = ['lib']
 solc_version = '0.8.15'
 
-rpc_endpoints = { MAINNET = "${MAINNET_RPC}", ARBITRUM = "${ARBITRUM_RPC}", UNIT_TESTS = "https://rpc.tenderly.co/fork/eb4cc00e-c12c-45f5-905a-04f0cfdefa2f", HARNESS = "https://rpc.tenderly.co/fork/78da602e-78a8-4705-b73c-3c62991231aa" }
+rpc_endpoints = { MAINNET = "${MAINNET_RPC}", ARBITRUM = "${ARBITRUM_RPC}", UNIT_TESTS = "https://rpc.tenderly.co/fork/eb4cc00e-c12c-45f5-905a-04f0cfdefa2f", MIGRATE_TESTS = "https://rpc.tenderly.co/fork/b9c353b6-37ae-4f9c-8649-5d23df9f862f", HARNESS = "https://rpc.tenderly.co/fork/78da602e-78a8-4705-b73c-3c62991231aa" }
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/src/Strategy.sol
+++ b/src/Strategy.sol
@@ -48,15 +48,7 @@ contract Strategy is AccessControl, ERC20Rewards, StrategyMigrator { // TODO: I'
         StrategyMigrator(
             IERC20(fyToken_.underlying()),
             fyToken_)
-    {
-        // Deploy with a seriesId_ matching the migrating strategy if using the migration feature
-        // Deploy with any series matching the desired base in any other case
-        fyToken = fyToken_;
-
-        base = IERC20(fyToken_.underlying());
-
-        _grantRole(Strategy.init.selector, address(this)); // Enable the `mint` -> `init` hook.
-    }
+    {}
 
     modifier isState(State target) {
         require (

--- a/src/Strategy.sol
+++ b/src/Strategy.sol
@@ -66,7 +66,7 @@ contract Strategy is AccessControl, ERC20Rewards, StrategyMigrator { // TODO: I'
         _;
     }
 
-    /// @dev State and state variable management
+    /// @notice State and state variable management
     /// @param target State to transition to
     /// @param pool_ If transitioning to invested, update pool state variable with this parameter
     function _transition(State target, IPool pool_) internal {
@@ -88,7 +88,7 @@ contract Strategy is AccessControl, ERC20Rewards, StrategyMigrator { // TODO: I'
         state = target;
     }
 
-    /// @dev State and state variable management
+    /// @notice State and state variable management
     /// @param target State to transition to
     function _transition(State target) internal {
         require (target != State.INVESTED, "Must provide a pool");
@@ -97,34 +97,23 @@ contract Strategy is AccessControl, ERC20Rewards, StrategyMigrator { // TODO: I'
 
     // ----------------------- INVEST & DIVEST --------------------------- //
 
-    /// @notice Mock pool mint called by a strategy when trying to migrate.
-    /// @dev Will initialize the strategy and return strategy tokens.
+    /// @notice Mint the first strategy tokens, without investing
+    /// @dev Returns additional values to match the pool init function and allow for strategy migrations.
     /// It is expected that base has been transferred in, but no fyTokens
     /// @return baseIn Amount of base tokens found in contract
     /// @return fyTokenIn This is always returned as 0 since they aren't used
     /// @return minted Amount of strategy tokens minted from base tokens which is the same as baseIn
-    function mint(address, address, uint256, uint256)
+    function init(address to)
         external
         override
         auth
         returns (uint256 baseIn, uint256 fyTokenIn, uint256 minted)
     {
         fyTokenIn = 0; // Silence compiler warning
-        baseIn = minted = _init(msg.sender);
+        baseIn = minted = _init(to);
     }
 
-    /// @dev Mint the first strategy tokens, without investing
-    /// @param to Recipient for the strategy tokens
-    /// @return minted Amount of strategy tokens minted from base tokens
-    function init(address to)
-        external
-        auth
-        returns (uint256 minted)
-    {
-        minted = _init(to);
-    }
-
-    /// @dev Mint the first strategy tokens, without investing
+    /// @notice Mint the first strategy tokens, without investing
     /// @param to Recipient for the strategy tokens
     /// @return minted Amount of strategy tokens minted from base tokens
     function _init(address to)
@@ -143,7 +132,7 @@ contract Strategy is AccessControl, ERC20Rewards, StrategyMigrator { // TODO: I'
         _transition(State.DIVESTED);
     }
 
-    /// @dev Start the strategy investments in the next pool
+    /// @notice Start the strategy investments in the next pool
     /// @param pool_ Pool to invest into
     /// @return poolTokensObtained Amount of pool tokens minted from base tokens
     /// @notice When calling this function for the first pool, some underlying needs to be transferred to the strategy first, using a batchable router.
@@ -174,7 +163,7 @@ contract Strategy is AccessControl, ERC20Rewards, StrategyMigrator { // TODO: I'
         emit Invested(address(pool_), baseCached_, poolTokensObtained);
     }
 
-    /// @dev Divest out of a pool once it has matured
+    /// @notice Divest out of a pool once it has matured
     /// @return baseObtained Amount of base tokens obtained from burning pool tokens   
     function divest()
         external
@@ -206,7 +195,7 @@ contract Strategy is AccessControl, ERC20Rewards, StrategyMigrator { // TODO: I'
 
     // ----------------------- EJECT --------------------------- //
 
-    /// @dev Divest out of a pool at any time. If possible the pool tokens will be burnt for base and fyToken, the latter of which
+    /// @notice Divest out of a pool at any time. If possible the pool tokens will be burnt for base and fyToken, the latter of which
     /// must be sold to return the strategy to a functional state. If the pool token burn reverts, the pool tokens will be transferred
     /// to the caller as a last resort.
     /// @return baseReceived Amount of base tokens received from pool tokens
@@ -242,8 +231,8 @@ contract Strategy is AccessControl, ERC20Rewards, StrategyMigrator { // TODO: I'
         }
     }
 
-    /// @dev Burn an amount of pool tokens.
-    /// @notice Only the Strategy itself can call this function. It is external and exists so that the transfer is reverted if the burn also reverts.
+    /// @notice Burn an amount of pool tokens.
+    /// @dev Only the Strategy itself can call this function. It is external and exists so that the transfer is reverted if the burn also reverts.
     /// @param pool_ Pool for the pool tokens.
     /// @param poolTokens Amount of tokens to burn.
     /// @return baseReceived Amount of base tokens received from pool tokens
@@ -263,7 +252,7 @@ contract Strategy is AccessControl, ERC20Rewards, StrategyMigrator { // TODO: I'
         require(fyToken.balanceOf(address(this)) - fyTokenBalance == fyTokenReceived, "Burn failed - fyToken");
     }
 
-    /// @dev Buy ejected fyToken in the strategy at face value
+    /// @notice Buy ejected fyToken in the strategy at face value
     /// @param fyTokenTo Address to send the purchased fyToken to.
     /// @param baseTo Address to send any remaining base to.
     /// @return soldFYToken Amount of fyToken sold.
@@ -301,7 +290,7 @@ contract Strategy is AccessControl, ERC20Rewards, StrategyMigrator { // TODO: I'
         emit SoldFYToken(soldFYToken, returnedBase);
     }
 
-    /// @dev If we drained the strategy, we can recapitalize it with base to avoid a forced migration
+    /// @notice If we drained the strategy, we can recapitalize it with base to avoid a forced migration
     /// @return baseIn Amount of base tokens used to restart
     function restart()
         external
@@ -316,7 +305,7 @@ contract Strategy is AccessControl, ERC20Rewards, StrategyMigrator { // TODO: I'
 
     // ----------------------- MINT & BURN --------------------------- //
 
-    /// @dev Mint strategy tokens with pool tokens. It can be called only when invested.
+    /// @notice Mint strategy tokens with pool tokens. It can be called only when invested.
     /// @param to Recipient for the strategy tokens
     /// @return minted Amount of strategy tokens minted
     /// @notice The pool tokens that the user contributes need to have been transferred previously, using a batchable router.
@@ -342,7 +331,7 @@ contract Strategy is AccessControl, ERC20Rewards, StrategyMigrator { // TODO: I'
         _mint(to, minted);
     }
 
-    /// @dev Burn strategy tokens to withdraw pool tokens. It can be called only when invested.
+    /// @notice Burn strategy tokens to withdraw pool tokens. It can be called only when invested.
     /// @param to Recipient for the pool tokens
     /// @return poolTokensObtained Amount of pool tokens obtained
     /// @notice The strategy tokens that the user burns need to have been transferred previously, using a batchable router.
@@ -367,7 +356,7 @@ contract Strategy is AccessControl, ERC20Rewards, StrategyMigrator { // TODO: I'
         poolCached = poolCached_ - poolTokensObtained;
     }
 
-    /// @dev Mint strategy tokens with base tokens. It can be called only when not invested and not ejected.
+    /// @notice Mint strategy tokens with base tokens. It can be called only when not invested and not ejected.
     /// @param to Recipient for the strategy tokens
     /// @return minted Amount of strategy tokens minted
     /// @notice The base tokens that the user invests need to have been transferred previously, using a batchable router.
@@ -386,7 +375,7 @@ contract Strategy is AccessControl, ERC20Rewards, StrategyMigrator { // TODO: I'
         _mint(to, minted);
     }
 
-    /// @dev Burn strategy tokens to withdraw base tokens. It can be called when not invested and not ejected.
+    /// @notice Burn strategy tokens to withdraw base tokens. It can be called when not invested and not ejected.
     /// @param to Recipient for the base tokens
     /// @return baseObtained Amount of base tokens obtained
     /// @notice The strategy tokens that the user burns need to have been transferred previously, using a batchable router.

--- a/src/StrategyMigrator.sol
+++ b/src/StrategyMigrator.sol
@@ -11,7 +11,7 @@ import {IERC20} from "@yield-protocol/utils-v2/src/token/IERC20.sol";
 abstract contract StrategyMigrator is IStrategyMigrator {
 
     /// Mock pool base - Must match that of the calling strategy
-    IERC20 public base;
+    IERC20 public immutable base;
 
     /// Mock pool fyToken - Can be any address
     IFYToken public fyToken;

--- a/src/StrategyMigrator.sol
+++ b/src/StrategyMigrator.sol
@@ -4,23 +4,19 @@ pragma solidity ^0.8.13;
 import {IStrategyMigrator} from "./interfaces/IStrategyMigrator.sol";
 import {IFYToken} from "@yield-protocol/vault-v2/src/interfaces/IFYToken.sol";
 import {IERC20} from "@yield-protocol/utils-v2/src/token/IERC20.sol";
-import {ERC20Permit} from "@yield-protocol/utils-v2/src/token/ERC20Permit.sol";
 
 
-/// @dev The Migrator contract poses as a Pool to receive all assets from a Strategy
-/// during a roll operation.
-/// @notice The Pool and fyToken must exist. The fyToken needs to be not mature, and the pool needs to have no fyToken in it.
-/// There will be no state changes on pool or fyToken.
-/// TODO: For this to work, the implementing class must inherit from ERC20 and make sure that totalSupply is not zero after the `mint` call.
+/// @dev The Migrator contract poses as a Pool to receive all assets from a Strategy during an invest call.
+/// TODO: For this to work, the implementing class must inherit from ERC20.
 abstract contract StrategyMigrator is IStrategyMigrator {
 
     /// Mock pool base - Must match that of the calling strategy
     IERC20 public base;
 
-    /// Mock pool fyToken - Must be set to a real fyToken registered to a series in the Cauldron, any will do
+    /// Mock pool fyToken - Can be any address
     IFYToken public fyToken;
 
-    /// Mock pool maturity - Its contents don't matter
+    /// Mock pool maturity - Can be set to a value far in the future to avoid `divest` calls
     uint32 public maturity;
 
     constructor(IERC20 base_, IFYToken fyToken_) {
@@ -28,8 +24,8 @@ abstract contract StrategyMigrator is IStrategyMigrator {
         fyToken = fyToken_;
     }
 
-    /// @dev Mock pool mint. Called within `startPool`. This contract must hold 1 wei of base.
-    function mint(address, address, uint256, uint256)
+    /// @dev Mock pool init. Called within `invest`.
+    function init(address)
         external
         virtual
         returns (uint256, uint256, uint256)
@@ -37,26 +33,12 @@ abstract contract StrategyMigrator is IStrategyMigrator {
         return (0, 0, 0);
     }
 
-    /// @dev Mock pool burn and make it revert so that `endPool`never suceeds, and `burnForBase` can never be called.
+    /// @dev Mock pool burn that reverts so that `divest` never suceeds, but `eject` does.
     function burn(address, address, uint256, uint256)
         external
-        returns  (uint256, uint256, uint256)
+        virtual
+        returns (uint256, uint256, uint256)
     {
         revert();
-    }
-
-    /// @dev Mock pool getBaseBalance
-    function getBaseBalance() external view returns(uint128) {
-        return 0;
-    }
-
-    /// @dev Mock pool getFYTokenBalance
-    function getFYTokenBalance() external view returns(uint128) {
-        return 0;
-    }
-
-    /// @dev Mock pool ts
-    function ts() external view returns(int128) {
-        return 0;
     }
 }

--- a/src/draft/StrategyV3.sol
+++ b/src/draft/StrategyV3.sol
@@ -85,11 +85,6 @@ contract StrategyV3 is AccessControl, ERC20Rewards, StrategyMigrator { // TODO: 
         ladle = ladle_;
         cauldron = ladle_.cauldron();
 
-        // Deploy with a seriesId_ matching the migrating strategy if using the migration feature
-        // Deploy with any series matching the desired base in any other case
-        fyToken = fyToken_;
-
-        base = IERC20(fyToken_.underlying());
         bytes6 baseId_;
         baseId = baseId_ = fyToken_.underlyingId();
         baseJoin = address(ladle_.joins(baseId_));

--- a/src/draft/StrategyV3.sol
+++ b/src/draft/StrategyV3.sol
@@ -160,25 +160,14 @@ contract StrategyV3 is AccessControl, ERC20Rewards, StrategyMigrator { // TODO: 
 
     // ----------------------- STATE CHANGES --------------------------- //
 
-    /// @dev Mock pool mint hooked up to initialize the strategy and return strategy tokens.
-    function mint(address, address, uint256, uint256)
+    /// @dev Mint the first strategy tokens, without investing.
+    /// @param to Receiver of the strategy tokens.
+    function init(address to)
         external
         override
         isState(State.DEPLOYED)
         auth
         returns (uint256 baseIn, uint256 fyTokenIn, uint256 minted)
-    {
-        baseIn = minted = this.init(msg.sender);
-        fyTokenIn = 0;
-    }
-
-    /// @dev Mint the first strategy tokens, without investing.
-    /// @param to Receiver of the strategy tokens.
-    function init(address to)
-        external
-        isState(State.DEPLOYED)
-        auth
-        returns (uint256 minted)
     {
         // Clear state variables from a potential migration
         delete seriesId;
@@ -188,7 +177,8 @@ contract StrategyV3 is AccessControl, ERC20Rewards, StrategyMigrator { // TODO: 
         delete vaultId;
 
         require (_totalSupply == 0, "Already initialized");
-        value = minted = base.balanceOf(address(this));
+        fyTokenIn = 0;
+        value = baseIn = minted = base.balanceOf(address(this));
         require (minted > 0, "Not enough base in");
         // Make sure that at the end of the transaction the strategy has enough tokens as to not expose itself to a rounding-down liquidity attack.
         _mint(to, minted);

--- a/src/interfaces/IStrategy.sol
+++ b/src/interfaces/IStrategy.sol
@@ -30,7 +30,7 @@ interface IStrategy is IStrategyMigrator {
     /// @dev Mint the first strategy tokens, without investing
     function init(address to)
         external
-        returns (uint256 minted);
+        returns (uint256 baseIn, uint256 fyTokenIn, uint256 minted);
 
     /// @dev Start the strategy investments in the next pool
     /// @notice When calling this function for the first pool, some underlying needs to be transferred to the strategy first, using a batchable router.

--- a/src/interfaces/IStrategyMigrator.sol
+++ b/src/interfaces/IStrategyMigrator.sol
@@ -14,24 +14,12 @@ interface IStrategyMigrator is IERC20 {
     /// @dev Mock pool base - Must match that of the calling strategy
     function base() external view returns(IERC20);
 
-    /// @dev Mock pool fyToken - Must be set to a real fyToken registered to a series in the Cauldron, any will do
+    /// @dev Mock pool fyToken - Can be any address, including address(0)
     function fyToken() external view returns(IFYToken);
 
-    /// @dev Mock pool mint. Called within `startPool`. This contract must hold 1 wei of base.
-    function mint(address, address, uint256, uint256) external returns (uint256, uint256, uint256);
+    /// @dev Mock pool init. Called within `invest`.
+    function init(address) external returns (uint256, uint256, uint256);
 
     /// @dev Mock pool burn and make it revert so that `endPool`never suceeds, and `burnForBase` can never be called.
     function burn(address, address, uint256, uint256) external returns  (uint256, uint256, uint256);
-
-    /// @dev Mock pool maturity
-    function maturity() external view returns(uint32);
-
-    /// @dev Mock pool getBaseBalance
-    function getBaseBalance() external view returns(uint128);
-
-    /// @dev Mock pool getFYTokenBalance
-    function getFYTokenBalance() external view returns(uint128);
-
-    /// @dev Mock pool ts
-    function ts() external view returns(int128);
 }

--- a/test/TestConstants.sol
+++ b/test/TestConstants.sol
@@ -31,6 +31,7 @@ contract TestConstants {
     string public constant LOCALHOST = "LOCALHOST";
     string public constant MAINNET = "MAINNET";
     string public constant ARBITRUM = "ARBITRUM";
+    string public constant MIGRATE_TESTS = "MIGRATE_TESTS";
     string public constant HARNESS = "HARNESS";
     string public constant MOCK = "MOCK";
     string public constant NETWORK = "NETWORK";

--- a/test/harness/StrategyHarness.t.sol
+++ b/test/harness/StrategyHarness.t.sol
@@ -201,7 +201,7 @@ abstract contract EjectedOrDrainedState is InvestedState {
 
 contract TestEjectedOrDrained is EjectedOrDrainedState {
     function testHarnessBuyFYTokenEjected() public skipOnCI onlyEjected {
-        console2.log("strategy.buyFYToken()");
+        console2.log("strategy.retrieveFYToken()");
 
         uint256 fyTokenAvailable = fyToken.balanceOf(address(strategy));
         track("aliceFYTokens", fyToken.balanceOf(alice));
@@ -210,33 +210,16 @@ contract TestEjectedOrDrained is EjectedOrDrainedState {
         track("strategyBaseTokens", baseToken.balanceOf(address(strategy)));
         track("baseCached", strategy.baseCached());
 
-        // initial buy - half of ejected fyToken balance
-        uint initialBuy = fyTokenAvailable / 2;
+        // retrieve all fyToken and donate an amount of base
+        uint baseDonated = fyTokenAvailable / 2;
         cash(baseToken, address(strategy), initialBuy);
-        (uint256 bought,) = strategy.buyFYToken(alice, bob);
+        (uint256 bought,) = strategy.retrieveFYToken(alice);
 
         assertEq(bought, initialBuy);
-        assertTrackPlusEq("aliceFYTokens", initialBuy, fyToken.balanceOf(alice));
-        assertTrackMinusEq("strategyFYToken", initialBuy, fyToken.balanceOf(address(strategy)));
-        assertTrackPlusEq("strategyBaseTokens", initialBuy, baseToken.balanceOf(address(strategy)));
-        assertTrackPlusEq("baseCached", initialBuy, strategy.baseCached());
-
-        // second buy - transfer in double the remaining fyToken and expect refund of base
-        track("bobBaseTokens", baseToken.balanceOf(address(bob)));
-        uint remainingFYToken = fyToken.balanceOf(address(strategy));
-        uint secondBuy = remainingFYToken * 2;
-        uint returned;
-        cash(baseToken, address(strategy), secondBuy);
-        (bought, returned) = strategy.buyFYToken(alice, bob);
-
-        assertEq(bought, remainingFYToken);
-        assertEq(returned, remainingFYToken);
-        assertEq(initialBuy + remainingFYToken, fyTokenAvailable);
         assertTrackPlusEq("aliceFYTokens", fyTokenAvailable, fyToken.balanceOf(alice));
-        assertTrackMinusEq("strategyFYToken", fyTokenAvailable, fyToken.balanceOf(address(strategy)));
-        assertTrackPlusEq("strategyBaseTokens", fyTokenAvailable, baseToken.balanceOf(address(strategy)));
-        assertTrackPlusEq("bobBaseTokens", secondBuy - remainingFYToken, baseToken.balanceOf(address(bob)));
-        assertTrackPlusEq("baseCached", fyTokenAvailable, strategy.baseCached());
+        assertEq(fyToken.balanceOf(address(strategy)), 0);
+        assertTrackPlusEq("strategyBaseTokens", baseDonated, baseToken.balanceOf(address(strategy)));
+        assertTrackPlusEq("baseCached", baseDonated, strategy.baseCached());
 
         // State variables are reset
         assertEq(address(strategy.fyToken()), address(0));
@@ -354,7 +337,7 @@ contract DivestedStateTest is DivestedState {
 //   eject -> Drained ✓
 //   time passes -> InvestedAfterMaturity  ✓
 // Ejected
-//   buyFYToken -> Divested ✓
+//   retrieveFYToken -> Divested ✓
 // Drained
 //   restart -> Divested ✓
 // InvestedAfterMaturity

--- a/test/harness/StrategyHarness.t.sol
+++ b/test/harness/StrategyHarness.t.sol
@@ -212,10 +212,10 @@ contract TestEjectedOrDrained is EjectedOrDrainedState {
 
         // retrieve all fyToken and donate an amount of base
         uint baseDonated = fyTokenAvailable / 2;
-        cash(baseToken, address(strategy), initialBuy);
-        (uint256 bought,) = strategy.retrieveFYToken(alice);
+        cash(baseToken, address(strategy), baseDonated);
+        (uint256 retrievedFYToken, uint256 baseAccepted) = strategy.retrieveFYToken(alice);
 
-        assertEq(bought, initialBuy);
+        assertEq(retrievedFYToken, fyTokenAvailable);
         assertTrackPlusEq("aliceFYTokens", fyTokenAvailable, fyToken.balanceOf(alice));
         assertEq(fyToken.balanceOf(address(strategy)), 0);
         assertTrackPlusEq("strategyBaseTokens", baseDonated, baseToken.balanceOf(address(strategy)));


### PR DESCRIPTION
Option to reduce damage if there is another `eject`, without incurring the risk of making the contract upgradable or adding a do-anything function. The fyToken can now be retrieved after an `eject` at any price (including zero), but only by permissioned accounts.