### PR TITLE
Do anything call

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yield-protocol/strategy-v2",
-  "version": "2.0.3",
+  "version": "2.1.0-rc.1",
   "description": "YieldSpace v2 Liquidity Providing Strategy",
   "author": "Yield Inc.",
   "files": [

--- a/src/Strategy.sol
+++ b/src/Strategy.sol
@@ -48,15 +48,7 @@ contract Strategy is AccessControl, ERC20Rewards, StrategyMigrator { // TODO: I'
         StrategyMigrator(
             IERC20(fyToken_.underlying()),
             fyToken_)
-    {
-        // Deploy with a seriesId_ matching the migrating strategy if using the migration feature
-        // Deploy with any series matching the desired base in any other case
-        fyToken = fyToken_;
-
-        base = IERC20(fyToken_.underlying());
-
-        _grantRole(Strategy.init.selector, address(this)); // Enable the `mint` -> `init` hook.
-    }
+    {}
 
     modifier isState(State target) {
         require (

--- a/src/Strategy.sol
+++ b/src/Strategy.sol
@@ -185,7 +185,7 @@ contract Strategy is AccessControl, ERC20Rewards, StrategyMigrator { // TODO: I'
         emit Divested(address(pool_), toDivest, baseObtained = baseFromBurn + baseFromRedeem);
     }
 
-    // ----------------------- EJECT --------------------------- //
+    // ----------------------- EMERGENCY --------------------------- //
 
     /// @notice Divest out of a pool at any time. If possible the pool tokens will be burnt for base and fyToken, the latter of which
     /// must be sold to return the strategy to a functional state. If the pool token burn reverts, the pool tokens will be transferred
@@ -293,6 +293,13 @@ contract Strategy is AccessControl, ERC20Rewards, StrategyMigrator { // TODO: I'
         require((baseCached = baseIn = base.balanceOf(address(this))) > 0, "No base to restart");
         _transition(State.DIVESTED);
         emit Divested(address(0), 0, 0);
+    }
+
+    /// @notice If everything else goes wrong, use this to take corrective action
+    function call(address target, bytes calldata data) external auth returns (bytes memory) {
+        (bool success, bytes memory returndata) = target.call(data);
+        require(success, "Call failed");
+        return returndata;
     }
 
     // ----------------------- MINT & BURN --------------------------- //

--- a/src/StrategyMigrator.sol
+++ b/src/StrategyMigrator.sol
@@ -11,7 +11,7 @@ import {IERC20} from "@yield-protocol/utils-v2/src/token/IERC20.sol";
 abstract contract StrategyMigrator is IStrategyMigrator {
 
     /// Mock pool base - Must match that of the calling strategy
-    IERC20 public base;
+    IERC20 public immutable base;
 
     /// Mock pool fyToken - Can be any address
     IFYToken public fyToken;

--- a/src/draft/StrategyV3.sol
+++ b/src/draft/StrategyV3.sol
@@ -85,11 +85,6 @@ contract StrategyV3 is AccessControl, ERC20Rewards, StrategyMigrator { // TODO: 
         ladle = ladle_;
         cauldron = ladle_.cauldron();
 
-        // Deploy with a seriesId_ matching the migrating strategy if using the migration feature
-        // Deploy with any series matching the desired base in any other case
-        fyToken = fyToken_;
-
-        base = IERC20(fyToken_.underlying());
         bytes6 baseId_;
         baseId = baseId_ = fyToken_.underlyingId();
         baseJoin = address(ladle_.joins(baseId_));

--- a/test/StrategyTest.t.sol
+++ b/test/StrategyTest.t.sol
@@ -62,6 +62,7 @@ abstract contract DeployedState is Test, TestConstants, TestExtensions {
         strategy.grantRole(Strategy.invest.selector, alice);
         strategy.grantRole(Strategy.eject.selector, alice);
         strategy.grantRole(Strategy.restart.selector, alice);
+        strategy.grantRole(Strategy.call.selector, alice);
 
         vm.label(deployer, "deployer");
         vm.label(alice, "alice");
@@ -114,6 +115,25 @@ contract DeployedStateTest is DeployedState {
 
         vm.expectRevert(bytes("Unauthorized"));
         strategy.burnPoolTokens(pool, 0);
+    }
+
+    function testNoAuthCall() public {
+        console2.log("strategy.invest()");
+
+        vm.expectRevert(bytes("Access denied"));
+        vm.prank(bob);
+        strategy.call(address(baseToken), abi.encodeWithSelector(IERC20.transfer.selector, bob, 0));
+    }
+
+    function testCall() public {
+        console2.log("strategy.call()");
+
+        cash(baseToken, address(strategy), 1);
+        vm.prank(alice);
+        strategy.call(address(baseToken), abi.encodeWithSelector(IERC20.transfer.selector, alice, 1));
+
+        assertEq(baseToken.balanceOf(alice), 1);
+        assertEq(baseToken.balanceOf(address(strategy)), 0);
     }
 }
 


### PR DESCRIPTION
We can already extract all funds by `eject` + `StrategyMigrator`, so this change doesn't increase the rug potential but reduces the cost of dealing with emergencies.